### PR TITLE
Refine: Display top 5 cities by population in city search

### DIFF
--- a/src/components/TimezonePicker.tsx
+++ b/src/components/TimezonePicker.tsx
@@ -63,9 +63,12 @@ export default function TimezonePicker({ onSelect }: TimezonePickerProps) {
         options={options}
         getOptionLabel={(option) => `${option.city}, ${option.country}`}
         filterOptions={(options, { inputValue }) => {
-          // If input is empty or has 1 character, show default list (first 15 cities)
+          // If input is empty or has 1 character, show top 5 most populous cities
           if (inputValue.length < 2) {
-            return options.slice(0, 15); 
+            // Sort all options by population in descending order and take the top 5
+            return options
+              .sort((a, b) => b.population - a.population)
+              .slice(0, 5);
           }
           
           // If input has 2 or more characters, apply existing filtering logic


### PR DESCRIPTION
Updates the city search functionality in TimezonePicker.tsx. When the input field is empty or has a single character, the component now displays the top 5 cities globally, sorted by population.

This replaces the previous behavior of showing the first 15 available timezones and directly addresses your feedback to provide a more relevant default list of cities. The standard search functionality for inputs with two or more characters remains unchanged.