### PR TITLE
Fix region filtering in CityService

### DIFF
--- a/src/components/__tests__/TimezoneRow.test.tsx
+++ b/src/components/__tests__/TimezoneRow.test.tsx
@@ -96,7 +96,7 @@ describe('TimezoneRow Component', () => {
     render(
       <TimezoneRow
         timezone={mockTimezoneNY}
-        selectedDateTime={baseSelectedTime}
+        selectedTime={baseSelectedTime}
         onTimeSelect={mockOnTimeSelect}
         onDelete={mockOnDelete}
         isDraggable={false}
@@ -119,7 +119,7 @@ describe('TimezoneRow Component', () => {
     render(
       <TimezoneRow
         timezone={mockTimezoneGMT10}
-        selectedDateTime={baseSelectedTime}
+        selectedTime={baseSelectedTime}
         onTimeSelect={mockOnTimeSelect}
         onDelete={mockOnDelete}
         isDraggable={false}
@@ -143,7 +143,7 @@ describe('TimezoneRow Component', () => {
     render(
       <TimezoneRow
         timezone={mockTimezoneBuenosAires}
-        selectedDateTime={baseSelectedTime}
+        selectedTime={baseSelectedTime}
         onTimeSelect={mockOnTimeSelect}
         onDelete={mockOnDelete}
         isDraggable={false}
@@ -162,7 +162,7 @@ describe('TimezoneRow Component', () => {
     render(
       <TimezoneRow
         timezone={mockTimezoneNY}
-        selectedDateTime={baseSelectedTime}
+        selectedTime={baseSelectedTime}
         onTimeSelect={mockOnTimeSelect}
         onDelete={mockOnDelete}
         isDraggable={false}
@@ -179,7 +179,7 @@ describe('TimezoneRow Component', () => {
     render(
       <TimezoneRow
         timezone={mockTimezoneInvalid}
-        selectedDateTime={baseSelectedTime}
+        selectedTime={baseSelectedTime}
         onTimeSelect={mockOnTimeSelect}
         onDelete={mockOnDelete}
         isDraggable={false}
@@ -207,7 +207,7 @@ describe('TimezoneRow Component', () => {
     render(
       <TimezoneRow
         timezone={mockTimezoneNY}
-        selectedDateTime={baseSelectedTime}
+        selectedTime={baseSelectedTime}
         onTimeSelect={mockOnTimeSelect}
         onDelete={mockOnDelete}
         isDraggable={false}


### PR DESCRIPTION
## Summary
- fix region filtering logic in CityService to use timezone prefixes
- update cache invalidation to match new region logic
- correct prop name in TimezoneRow tests

## Testing
- `npm install`
- `npm test` *(fails: selectedTime.toUTC is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68693a56a2f08329bc627f765951c04a