### PR TITLE
Improve timezone picker UTC alias search

### DIFF
--- a/src/__tests__/components/TimezonePicker.test.tsx
+++ b/src/__tests__/components/TimezonePicker.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TimezonePicker from '../../components/TimezonePicker';
+
+describe('TimezonePicker search behaviour', () => {
+  it('reveals Etc/GMT-5 when searching for UTC+5', async () => {
+    const user = userEvent.setup();
+    render(<TimezonePicker onSelect={jest.fn()} />);
+
+    const input = screen.getByLabelText(/select or search for a city/i);
+    await user.type(input, 'UTC+5');
+
+    expect(await screen.findByRole('option', { name: /GMT\+5, TZ/i })).toBeInTheDocument();
+  });
+
+  it('shows GMT offset entries when searching for UTC', async () => {
+    const user = userEvent.setup();
+    render(<TimezonePicker onSelect={jest.fn()} />);
+
+    const input = screen.getByLabelText(/select or search for a city/i);
+    await user.type(input, 'UTC');
+
+    expect(await screen.findByRole('option', { name: /GMT\+5, TZ/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/TimezonePicker.tsx
+++ b/src/components/TimezonePicker.tsx
@@ -17,6 +17,86 @@ import { Timezone } from '../types';
 import { getAvailableTimezones } from '../data/timezones';
 import CitySearchDialog from './CitySearchDialog';
 
+const normalizeKeyword = (value: string): string =>
+  value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[＋﹢]/g, '+')
+    .replace(/[‐‑‒–—−﹣－]/g, '-')
+    .replace(/\s+/g, '');
+
+const getTimezoneAliases = (timezoneId?: string): string[] => {
+  if (!timezoneId) {
+    return [];
+  }
+
+  const aliases = new Set<string>();
+  const normalizedId = timezoneId.trim();
+
+  if (normalizedId === 'UTC' || normalizedId === 'Etc/UTC') {
+    ['UTC', 'GMT', 'UTC+0', 'UTC-0', 'UTC+00', 'UTC-00', 'UTC+00:00', 'UTC-00:00'].forEach(alias =>
+      aliases.add(alias)
+    );
+    return Array.from(aliases);
+  }
+
+  if (normalizedId === 'Etc/GMT') {
+    ['UTC', 'GMT', 'UTC+0', 'UTC-0', 'UTC+00', 'UTC-00', 'UTC+00:00', 'UTC-00:00', 'GMT+0', 'GMT-0'].forEach(alias =>
+      aliases.add(alias)
+    );
+    return Array.from(aliases);
+  }
+
+  const etcMatch = normalizedId.match(/^Etc\/GMT([+-])(\d{1,2})$/i);
+  if (!etcMatch) {
+    return [];
+  }
+
+  const [, sign, hours] = etcMatch;
+  const actualSign = sign === '-' ? '+' : '-';
+  const paddedHours = hours.padStart(2, '0');
+
+  [
+    `UTC${actualSign}${hours}`,
+    `UTC${actualSign}${paddedHours}`,
+    `UTC${actualSign}${hours}:00`,
+    `UTC${actualSign}${paddedHours}:00`,
+    `GMT${actualSign}${hours}`,
+    `GMT${actualSign}${paddedHours}`,
+    `GMT${actualSign}${hours}:00`,
+    `GMT${actualSign}${paddedHours}:00`,
+    'UTC',
+    'GMT'
+  ].forEach(alias => aliases.add(alias));
+
+  return Array.from(aliases);
+};
+
+const buildNormalizedKeywords = (option: Timezone): string[] => {
+  const keywords = new Set<string>();
+  const timezoneId = option.id || option.timezone;
+
+  const addKeyword = (value?: string | null) => {
+    if (value) {
+      keywords.add(normalizeKeyword(value));
+    }
+  };
+
+  addKeyword(option.city);
+  addKeyword(option.country);
+  addKeyword(option.name);
+  addKeyword(option.timezone);
+  addKeyword(option.id);
+
+  if (timezoneId) {
+    addKeyword(timezoneId.replace(/_/g, ' '));
+    timezoneId.split(/[\/_]/).forEach(part => addKeyword(part));
+    getTimezoneAliases(timezoneId).forEach(addKeyword);
+  }
+
+  return Array.from(keywords);
+};
+
 interface TimezonePickerProps {
   onSelect: (timezone: Timezone) => void;
 }
@@ -106,11 +186,14 @@ export default function TimezonePicker({ onSelect }: TimezonePickerProps) {
             return regionalTopCities;
           }
 
-          // If input has 2 or more characters, apply existing filtering logic
-          const searchTerm = inputValue.toLowerCase().trim();
-          return options.filter(option => 
-            option.city.toLowerCase().includes(searchTerm) ||
-            option.country.toLowerCase().includes(searchTerm)
+          const normalizedSearchTerm = normalizeKeyword(inputValue);
+
+          if (!normalizedSearchTerm) {
+            return [...options];
+          }
+
+          return options.filter(option =>
+            buildNormalizedKeywords(option).some(keyword => keyword.includes(normalizedSearchTerm))
           );
         }}
         autoComplete


### PR DESCRIPTION
## Summary
- normalize search keywords in `TimezonePicker` and add UTC/GMT alias generation so UTC-style queries discover fixed-offset zones
- adjust the Jest setup to reuse the real Luxon API with deterministic `DateTime.now` and provide a `scrollIntoView` stub for DOM parity
- add focused tests that type UTC queries into the picker and confirm the `Etc/GMT-5` option becomes visible

## Testing
- ❌ `npm test` *(fails in existing CitySearchDialog/TimezoneRow suites unrelated to the new picker aliases)*
- ✅ `npx jest --config jest.config.cjs --runTestsByPath src/__tests__/components/TimezonePicker.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68d0e4d29d3c832bab0c903f0d4872fb