### PR TITLE
Add timezone abbreviations to alias generation

### DIFF
--- a/src/__tests__/data/timezoneAliases.test.ts
+++ b/src/__tests__/data/timezoneAliases.test.ts
@@ -1,0 +1,28 @@
+import { getAvailableTimezones } from '../../data/timezones'
+
+const timezones = getAvailableTimezones()
+
+const getAliasesForTimezone = (id: string): string[] => {
+  const timezone = timezones.find(tz => tz.id === id)
+  if (!timezone) {
+    throw new Error(`Timezone with id ${id} not found`)
+  }
+  return timezone.aliases
+}
+
+describe('timezone aliases include common abbreviations', () => {
+  it('includes PST and PDT for America/Los_Angeles', () => {
+    const aliases = getAliasesForTimezone('America/Los_Angeles')
+    expect(aliases).toEqual(expect.arrayContaining(['PST', 'PDT']))
+  })
+
+  it('includes EST and EDT for America/New_York', () => {
+    const aliases = getAliasesForTimezone('America/New_York')
+    expect(aliases).toEqual(expect.arrayContaining(['EST', 'EDT']))
+  })
+
+  it('includes CST and CDT for America/Chicago', () => {
+    const aliases = getAliasesForTimezone('America/Chicago')
+    expect(aliases).toEqual(expect.arrayContaining(['CST', 'CDT']))
+  })
+})

--- a/src/data/timezones.ts
+++ b/src/data/timezones.ts
@@ -79,6 +79,17 @@ export const generateTimezoneAliases = (timezoneId: string): string[] => {
       aliases.add(abbreviation.toUpperCase())
     }
 
+    const offsetNameShort = dateTime.offsetNameShort
+    if (offsetNameShort && offsetNameShort.toUpperCase() !== 'UTC' && offsetNameShort.toUpperCase() !== 'GMT') {
+      aliases.add(offsetNameShort.toUpperCase())
+    }
+
+    const offsetNameLong = dateTime.offsetNameLong
+    if (offsetNameLong) {
+      aliases.add(offsetNameLong)
+      aliases.add(offsetNameLong.toUpperCase())
+    }
+
     buildOffsetAliases(dateTime.offset).forEach(alias => aliases.add(alias))
   })
 


### PR DESCRIPTION
## Summary
- add offset-based short and long names to timezone alias generation so common abbreviations like PST/EST are searchable
- add unit tests to ensure US daylight and standard time abbreviations are present in the generated aliases

## Testing
- npm test -- --runTestsByPath src/__tests__/data/timezoneAliases.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d898c732748329aec9a62c6862287c